### PR TITLE
TypeScript Support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,13 @@
+declare const onGod = true;
+declare const noCap = true;
+declare const cap = false;
+
+declare var lowkey: Console & {
+  stan: Console["log"];
+  sus: Console["warn"];
+  cringe: Console["error"];
+};
+
+declare var L: typeof Error;
+
+declare function yeet(error: any): never;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "1.0.5",
     "description": "babel plugin to transpile internet slang into valid javascript",
     "main": "index.js",
+    "types": "index.d.ts",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
         "build": "babel ./src/example.js --out-file ./lib/compiled.js"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
Not sure how to handle `ghosted` and `return null` just yet.

The TSConfig is only to demo these types in the source file, to show that it works at the type-checking level. To use the types in TS with this plugin, you just have to add `babel-plugin-glowup-vibes` to your own TSConfig in the `types` config option, and use Babel to transpile your TypeScript down to JS. Or another option is that you could use `// @ts-check` if you don't want to use the full TS syntax.