### PR TITLE
Replace chill with setTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Note: this was designed using Babel 7 and I haven't tested it on anything else. 
 ## Options
 
 | Your Code                                       | JS                                                   |
-| ----------------------------------------------- | ---------------------------------------------------- |
+|-------------------------------------------------|------------------------------------------------------|
 | noCap                                           | true                                                 |
 | cap                                             | false                                                |
 | onGod                                           | true                                                 |
@@ -91,6 +91,7 @@ Note: this was designed using Babel 7 and I haven't tested it on anything else. 
 | clapback(1)                                     | yield 1                                              |
 | finna("message")                                | confirm("message")                                   |
 | document.vibeOnEvent(event, function, options); | document.addEventListener(event, function, options); |
+| chill(args)                                     | setTimeout(args)                                     |
 
 ## Contributing
 

--- a/identifierMappings.js
+++ b/identifierMappings.js
@@ -27,4 +27,5 @@ module.exports = {
   take: "fill",
   vibeOnEvent: "addEventListener",
   slay: "continue",
+  chill: "setTimeout",
 };

--- a/lib/compiled.js
+++ b/lib/compiled.js
@@ -12,7 +12,7 @@ function vibeCheck() {
     heat: "Yuh I'm droppin dis heat ❗❗",
     letHimCook: function letHimCook() {
       return this.heat;
-    },
+    }
   };
   console.debug("The crow screams murder".toUpperCase());
   for (let i = 0; i < 2; i++) {
@@ -25,6 +25,9 @@ function vibeCheck() {
   console.log(myGuy.letHimCook());
   console.warn("the vibes might be off 💀");
   assert(typeof sis === "function");
+  setTimeout(() => {
+    console.log("Let's chill for a sec.");
+  }, 1000);
   if (!theVibe) {
     const severalSeats = new Array(2);
     severalSeats.fill(true);

--- a/src/example.js
+++ b/src/example.js
@@ -30,6 +30,10 @@ function vibeCheck() {
 
   fr(typeof sis === "function");
 
+  chill(() => {
+    lowkey.stan("Let's chill for a sec.");
+  }, 1000);
+
   if (!theVibe) {
     const severalSeats = new SeveralSeats(2);
     severalSeats.take(true);

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -216,3 +216,13 @@ test("Should replace slay with continue", () => {
   }).code;
   expect(output).toEqual(expected);
 });
+
+test("Should replace chill with setTimeout", () => {
+  const input = `chill`;
+  const expected = `"use strict";\n\nsetTimeout;`;
+  const output = babel.transform(input, {
+    filename: "./../src/example.js",
+    plugins: [glowupVibes],
+  }).code;
+  expect(output).toEqual(expected);
+});


### PR DESCRIPTION
Implementation to replace _chill_ with _setTimeout_.

- Adjusted table in README.md
- Provided and example
```js
chill(() => {
  lowkey.stan("Let's chill for a sec.");
}, 1000);
```
- Tested with `npm run build`
- Added test case
- Format code with `npm run lint`

resolves #57 chill -> setTimeout