### PR TITLE
Replace highkey with alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Note: this was designed using Babel 7 and I haven't tested it on anything else. 
 ## Options
 
 | Your Code                                       | JS                                                   |
-| ----------------------------------------------- | ---------------------------------------------------- |
+|-------------------------------------------------|------------------------------------------------------|
 | noCap                                           | true                                                 |
 | cap                                             | false                                                |
 | onGod                                           | true                                                 |
@@ -91,6 +91,7 @@ Note: this was designed using Babel 7 and I haven't tested it on anything else. 
 | clapback(1)                                     | yield 1                                              |
 | finna("message")                                | confirm("message")                                   |
 | document.vibeOnEvent(event, function, options); | document.addEventListener(event, function, options); |
+| highkey("message")                              | alert("message")                                                    |
 
 ## Contributing
 

--- a/identifierMappings.js
+++ b/identifierMappings.js
@@ -27,4 +27,5 @@ module.exports = {
   take: "fill",
   vibeOnEvent: "addEventListener",
   slay: "continue",
+  highkey: "alert",
 };

--- a/lib/compiled.js
+++ b/lib/compiled.js
@@ -12,7 +12,7 @@ function vibeCheck() {
     heat: "Yuh I'm droppin dis heat ❗❗",
     letHimCook: function letHimCook() {
       return this.heat;
-    },
+    }
   };
   console.debug("The crow screams murder".toUpperCase());
   for (let i = 0; i < 2; i++) {
@@ -25,6 +25,7 @@ function vibeCheck() {
   console.log(myGuy.letHimCook());
   console.warn("the vibes might be off 💀");
   assert(typeof sis === "function");
+  alert("highkey alerting!");
   if (!theVibe) {
     const severalSeats = new Array(2);
     severalSeats.fill(true);

--- a/src/example.js
+++ b/src/example.js
@@ -30,6 +30,8 @@ function vibeCheck() {
 
   fr(typeof sis === "function");
 
+  highkey("Highkey alerting!");
+
   if (!theVibe) {
     const severalSeats = new SeveralSeats(2);
     severalSeats.take(true);

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -216,3 +216,23 @@ test("Should replace slay with continue", () => {
   }).code;
   expect(output).toEqual(expected);
 });
+
+test("Should replace highkey with alert", () => {
+  const input = `highkey`;
+  const expected = `"use strict";\n\nhighkey;`;
+  const output = babel.transform(input, {
+    filename: "./../src/example.js",
+    plugins: [glowupVibes],
+  }).code;
+  expect(output).toEqual(expected);
+});
+
+test("Should not replace highkey in StringLiteral", () => {
+  const input = `highkey("highkey")`;
+  const expected = `"use strict";\n\nalert("highkey");`;
+  const output = babel.transform(input, {
+    filename: "./../src/example.js",
+    plugins: [glowupVibes],
+  }).code;
+  expect(output).toEqual(expected);
+});


### PR DESCRIPTION
Implementation to replace highkey with alert.

- Adjusted table in README.md
- Provided and example
```js
highkey("Highkey alerting!");
```
- Tested with npm run build
- Added test case
- Format code with npm run lint

resolves #63 
