### PR TITLE
Add support for yapping (comments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,46 +61,48 @@ Note: this was designed using Babel 7 and I haven't tested it on anything else. 
 
 ## Options
 
-| Your Code                                       | JS                                                   |
-|-------------------------------------------------|------------------------------------------------------|
-| noCap                                           | true                                                 |
-| cap                                             | false                                                |
-| onGod                                           | true                                                 |
-| lowkey.stan("message")                          | console.log("message")                               |
-| lowkey.sus("message")                           | console.warn("message")                              |
-| lowkey.crowed("message")                        | console.debug("message")                             |
-| lowkey.cringe("message")                        | console.error("message")                             |
-| lowkey.tea("message")                           | console.info("message")                              |
-| throw new L("message")                          | throw new Error("message")                           |
-| yeet(new L("message"))                          | throw new Error("message")                           |
-| ghosted                                         | return null                                          |
-| drop(thingToReturn)                             | return thingToReturn;                                |
-| itsGiving(thingToReturn)                        | return thingToReturn;                                |
-| spit(thingToReturn)                             | return thingToReturn;                                |
-| period                                          | break                                                |
-| PERIODT                                         | break                                                |
-| PERIODTTT                                       | break                                                |
-| skrt                                            | break                                                |
-| holdUp(veryCoolFunction)                        | async function veryCoolFunction()                    |
-| letItCook(thingToAwait)                         | await thingToAwait                                   |
-| grab("stash")                                   | require("stash")                                     |
-| module.ship = vibe                              | module.exports = vibe                                |
-| fr(assertion)                                   | assert(assertion)                                    |
-| outOfPocket                                     | Infinity                                             |
-| "BLAT".based()                                  | "BLAT".toLowerCase()                                 |
-| "blat".goated()                                 | "blat".toUpperCase()                                 |
-| dis                                             | this                                                 |
-| clapback(1)                                     | yield 1                                              |
-| finna("message")                                | confirm("message")                                   |
-| document.vibeOnEvent(event, function, options); | document.addEventListener(event, function, options); |
-| highkey("message")                              | alert("message")                                                    |
-| Bet                                             | Promise                                              |
-| chill(args)                                     | setTimeout(args)                                     |
-| arr.mew(args)                                   | arr.map(args)                                        |
-| arr.skibidi(args)                               | arr.filter(args)                                     |
-| arr.justPutTheFriesInTheBagBro(args)            | arr.reduce(args)                                     |
-| toilet(thingToReturn)                           | return thingToReturn;                                |
-| ohio                                            | null                                                 |
+| Your Code                                                              | JS                                                   |
+|------------------------------------------------------------------------|------------------------------------------------------|
+| noCap                                                                  | true                                                 |
+| cap                                                                    | false                                                |
+| onGod                                                                  | true                                                 |
+| lowkey.stan("message")                                                 | console.log("message")                               |
+| lowkey.sus("message")                                                  | console.warn("message")                              |
+| lowkey.crowed("message")                                               | console.debug("message")                             |
+| lowkey.cringe("message")                                               | console.error("message")                             |
+| lowkey.tea("message")                                                  | console.info("message")                              |
+| throw new L("message")                                                 | throw new Error("message")                           |
+| yeet(new L("message"))                                                 | throw new Error("message")                           |
+| ghosted                                                                | return null                                          |
+| drop(thingToReturn)                                                    | return thingToReturn;                                |
+| itsGiving(thingToReturn)                                               | return thingToReturn;                                |
+| spit(thingToReturn)                                                    | return thingToReturn;                                |
+| period                                                                 | break                                                |
+| PERIODT                                                                | break                                                |
+| PERIODTTT                                                              | break                                                |
+| skrt                                                                   | break                                                |
+| holdUp(veryCoolFunction)                                               | async function veryCoolFunction()                    |
+| letItCook(thingToAwait)                                                | await thingToAwait                                   |
+| grab("stash")                                                          | require("stash")                                     |
+| module.ship = vibe                                                     | module.exports = vibe                                |
+| fr(assertion)                                                          | assert(assertion)                                    |
+| outOfPocket                                                            | Infinity                                             |
+| "BLAT".based()                                                         | "BLAT".toLowerCase()                                 |
+| "blat".goated()                                                        | "blat".toUpperCase()                                 |
+| dis                                                                    | this                                                 |
+| clapback(1)                                                            | yield 1                                              |
+| finna("message")                                                       | confirm("message")                                   |
+| document.vibeOnEvent(event, function, options);                        | document.addEventListener(event, function, options); |
+| highkey("message")                                                     | alert("message")                                     |
+| Bet                                                                    | Promise                                              |
+| chill(args)                                                            | setTimeout(args)                                     |
+| arr.mew(args)                                                          | arr.map(args)                                        |
+| arr.skibidi(args)                                                      | arr.filter(args)                                     |
+| arr.justPutTheFriesInTheBagBro(args)                                   | arr.reduce(args)                                     |
+| toilet(thingToReturn)                                                  | return thingToReturn;                                |
+| ohio                                                                   | null                                                 |
+| yappingStarts comment yappingEnds                                      | /* comment */                                        |
+| <pre>yappingStarts yap<br>  yap @returns {string}<br>yappingEnds</pre> | <pre>/**<br> * @returns {string}<br> */</pre>        |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ Note: this was designed using Babel 7 and I haven't tested it on anything else. 
 | arr.justPutTheFriesInTheBagBro(args)                                   | arr.reduce(args)                                     |
 | toilet(thingToReturn)                                                  | return thingToReturn;                                |
 | ohio                                                                   | null                                                 |
-| yappingStarts comment yappingEnds                                      | /* comment */                                        |
+| yap single line comment                                                | // single line comment                               |
+| yappingStarts block comment yappingEnds                                | /* block comment */                                  |
 | <pre>yappingStarts yap<br>  yap @returns {string}<br>yappingEnds</pre> | <pre>/**<br> * @returns {string}<br> */</pre>        |
 
 ## Contributing

--- a/identifierMappings.js
+++ b/identifierMappings.js
@@ -37,6 +37,4 @@ module.exports = {
   justPutTheFriesInTheBagBro: "reduce",
   toilet: "return",
   ohio: "null",
-  yappingStarts: "/*",
-  yappingEnds: "*/",
 };

--- a/identifierMappings.js
+++ b/identifierMappings.js
@@ -37,4 +37,6 @@ module.exports = {
   justPutTheFriesInTheBagBro: "reduce",
   toilet: "return",
   ohio: "null",
+  yappingStarts: "/*",
+  yappingEnds: "*/",
 };

--- a/lib/compiled.js
+++ b/lib/compiled.js
@@ -62,6 +62,10 @@ function vibeCheck() {
     console.log("SLAY".toLowerCase());
     return null;
   }
+
+  /*
+    hawk tuah!
+  */
   return("🔥");
 }
 module.exports = vibeCheck;

--- a/lib/compiled.js
+++ b/lib/compiled.js
@@ -4,6 +4,9 @@ require("core-js/modules/es.promise.js");
 async function sis() {
   await vibeCheck;
 }
+/**
+ * @returns {(true | null)}
+ */
 function vibeCheck() {
   const theVibe = false;
   const rizz = confirm("u simpin'?") ? false : true;

--- a/lib/compiled.js
+++ b/lib/compiled.js
@@ -18,6 +18,8 @@ function vibeCheck() {
   auraPoints.filter(() => {
     return(null);
   });
+
+  // got rizz
   const myGuy = {
     heat: "Yuh I'm droppin dis heat ❗❗",
     letHimCook: function letHimCook() {
@@ -27,7 +29,7 @@ function vibeCheck() {
   console.debug("The crow screams murder".toUpperCase());
   for (let i = 0; i < 2; i++) {
     if (theVibe) {
-      continue;
+      continue; // Yaaaaaas
     } else {
       console.log("Not the vibe");
     }

--- a/lib/compiled.js
+++ b/lib/compiled.js
@@ -32,6 +32,8 @@ function vibeCheck() {
       console.log("Not the vibe");
     }
   }
+
+  /* More emojis needed tbh */
   const emoji = "???";
   const onlySometimes = '😭';
   console.error(onlySometimes + emoji);

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "jest": {
     "transformIgnorePatterns": [
       "/node_modules/",
-      "./identifierMappings.js"
+      "./identifierMappings.js",
+      "./preParser.js"
     ]
   }
 }

--- a/preParser.js
+++ b/preParser.js
@@ -35,11 +35,12 @@ module.exports = function (code, opts) {
             i += word.length - 1;
             break;
           case "yap":
-            if (code.slice(i - 14, i) === "yappingStarts ") {
-              insideJSDoc = true;
+            insideJSDoc ||= code.slice(i - 14, i) === "yappingStarts ";
+            if (insideJSDoc) {
+              parsed = parsed.slice(0, -1) + "*";
+            } else {
+              parsed += "//";
             }
-            parsed = insideJSDoc ? parsed.slice(0, -1) : parsed;
-            parsed += "*";
             i += word.length - 1;
             break;
           default:
@@ -51,4 +52,3 @@ module.exports = function (code, opts) {
   }
   return parser.parse(parsed, opts);
 };
-

--- a/preParser.js
+++ b/preParser.js
@@ -16,6 +16,7 @@ module.exports = function (code, opts) {
         insideLiteral = true;
       }
 
+      // Sob emoji for semicolon
       if (ch == "\uD83D" && code[++i] == "\uDE2D") {
         parsed += ";";
       } else if (ch !== "y") {

--- a/preParser.js
+++ b/preParser.js
@@ -4,6 +4,7 @@ module.exports = function (code, opts) {
   const literalIndictors = ['"', "'", "`"];
   let currentIndicator;
   let insideLiteral = false;
+  let insideJSDoc = false;
   let parsed = "";
   for (let i = 0, ch; (ch = code[i]); i++) {
     if (insideLiteral) {
@@ -25,7 +26,15 @@ module.exports = function (code, opts) {
           parsed += "/*";
           i += word.length - 1;
         } else if (word === "yappingEnds") {
-          parsed += "*/";
+          parsed += insideJSDoc ? " */" : "*/";
+          insideJSDoc = false;
+          i += word.length - 1;
+        } else if (word === "yap") {
+          if (code.slice(i - 14, i) === "yappingStarts ") {
+            insideJSDoc = true;
+          }
+          parsed = insideJSDoc ? parsed.slice(0, -1) : parsed;
+          parsed += "*";
           i += word.length - 1;
         } else {
           parsed += ch;

--- a/preParser.js
+++ b/preParser.js
@@ -1,5 +1,11 @@
 const parser = require("@babel/parser");
 
+const yap = {
+  start: "yappingStarts",
+  end: "yappingEnds",
+  single: "yap",
+};
+
 module.exports = function (code, opts) {
   const literalIndictors = ['"', "'", "`"];
   let currentIndicator;
@@ -25,28 +31,27 @@ module.exports = function (code, opts) {
         const word = code.slice(i).match(/^\w+/)?.[0];
 
         switch (word) {
-          case "yappingStarts":
+          case yap.start:
             parsed += "/*";
-            i += word.length - 1;
             break;
-          case "yappingEnds":
+          case yap.end:
             parsed += insideJSDoc ? " */" : "*/";
             insideJSDoc = false;
-            i += word.length - 1;
             break;
-          case "yap":
-            insideJSDoc ||= code.slice(i - 14, i) === "yappingStarts ";
+          case yap.single:
+            insideJSDoc ||= code.slice(i - 14, i) === yap.start + " ";
             if (insideJSDoc) {
               parsed = parsed.slice(0, -1) + "*";
             } else {
               parsed += "//";
             }
-            i += word.length - 1;
             break;
           default:
             parsed += ch;
             break;
         }
+
+        i += Object.values(yap).includes(word) ? word.length - 1 : 0;
       }
     }
   }

--- a/preParser.js
+++ b/preParser.js
@@ -22,22 +22,28 @@ module.exports = function (code, opts) {
         parsed += ch;
       } else {
         const word = code.slice(i).match(/^\w+/)?.[0];
-        if (word === "yappingStarts") {
-          parsed += "/*";
-          i += word.length - 1;
-        } else if (word === "yappingEnds") {
-          parsed += insideJSDoc ? " */" : "*/";
-          insideJSDoc = false;
-          i += word.length - 1;
-        } else if (word === "yap") {
-          if (code.slice(i - 14, i) === "yappingStarts ") {
-            insideJSDoc = true;
-          }
-          parsed = insideJSDoc ? parsed.slice(0, -1) : parsed;
-          parsed += "*";
-          i += word.length - 1;
-        } else {
-          parsed += ch;
+
+        switch (word) {
+          case "yappingStarts":
+            parsed += "/*";
+            i += word.length - 1;
+            break;
+          case "yappingEnds":
+            parsed += insideJSDoc ? " */" : "*/";
+            insideJSDoc = false;
+            i += word.length - 1;
+            break;
+          case "yap":
+            if (code.slice(i - 14, i) === "yappingStarts ") {
+              insideJSDoc = true;
+            }
+            parsed = insideJSDoc ? parsed.slice(0, -1) : parsed;
+            parsed += "*";
+            i += word.length - 1;
+            break;
+          default:
+            parsed += ch;
+            break;
         }
       }
     }

--- a/preParser.js
+++ b/preParser.js
@@ -1,20 +1,38 @@
 const parser = require("@babel/parser");
 
 module.exports = function (code, opts) {
-  const literalIndictors = ['"', '\'', '`'];
+  const literalIndictors = ['"', "'", "`"];
   let currentIndicator;
-  let insideLiteral = false
+  let insideLiteral = false;
   let parsed = "";
-  for (let i=0, ch; ch = code[i]; i++) {
+  for (let i = 0, ch; (ch = code[i]); i++) {
     if (insideLiteral) {
-      insideLiteral = !(ch == currentIndicator && code[i-1] != '\\')
+      insideLiteral = !(ch == currentIndicator && code[i - 1] != "\\");
+      parsed += ch;
     } else {
       if (literalIndictors.includes(ch)) {
         currentIndicator = ch;
-        insideLiteral = true
+        insideLiteral = true;
+      }
+
+      if (ch == "\uD83D" && code[++i] == "\uDE2D") {
+        parsed += ";";
+      } else if (ch !== "y") {
+        parsed += ch;
+      } else {
+        const word = code.slice(i).match(/^\w+/)?.[0];
+        if (word === "yappingStarts") {
+          parsed += "/*";
+          i += word.length - 1;
+        } else if (word === "yappingEnds") {
+          parsed += "*/";
+          i += word.length - 1;
+        } else {
+          parsed += ch;
+        }
       }
     }
-    parsed += (!insideLiteral && ch == "\uD83D" && code[++i] == "\uDE2D") ? ";" : ch;
   }
-  return parser.parse(parsed, opts)
-}
+  return parser.parse(parsed, opts);
+};
+

--- a/src/example.js
+++ b/src/example.js
@@ -36,6 +36,7 @@ function vibeCheck() {
     }
   }
 
+  yappingStarts More emojis needed tbh yappingEnds
   const emoji = "???"😭
   const onlySometimes = '😭';
   lowkey.cringe(onlySometimes + emoji);

--- a/src/example.js
+++ b/src/example.js
@@ -19,6 +19,7 @@ function vibeCheck() {
     toilet(ohio)
   });
 
+  yap got rizz
   const myGuy = {
     heat: "Yuh I'm droppin dis heat ❗❗",
 
@@ -30,7 +31,7 @@ function vibeCheck() {
   lowkey.crowed("The crow screams murder".goated());
   for (let i = 0; i < 2; i++) {
     if (theVibe) {
-      slay;
+      slay; yap Yaaaaaas
     } else {
       lowkey.stan("Not the vibe");
     }

--- a/src/example.js
+++ b/src/example.js
@@ -75,6 +75,9 @@ function vibeCheck() {
     ghosted;
   }
 
+  yappingStarts
+    hawk tuah!
+  yappingEnds
   spit("🔥");
 }
 

--- a/src/example.js
+++ b/src/example.js
@@ -2,6 +2,9 @@ holdUp(function sis() {
   letItCook(vibeCheck);
 });
 
+yappingStarts yap
+  yap @returns {(true | null)}
+yappingEnds
 function vibeCheck() {
   const theVibe = cap;
   const rizz = finna("u simpin'?") ? cap : onGod;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -359,3 +359,26 @@ test("Should replace ohio with reduce", () => {
   }).code;
   expect(output).toEqual(expected);
 });
+
+test("Should replace yappingStarts and yappingEnds with /* and */", () => {
+  const oneLinerInput = `yappingStarts this is a comment yappingEnds`;
+  const oneLinerExpected = `/* this is a comment */\n"use strict";`;
+  const oneLinerOutput = babel.transform(oneLinerInput, {
+    filename: "./../src/example.js",
+    plugins: [glowupVibes],
+  }).code;
+  expect(oneLinerOutput).toEqual(oneLinerExpected);
+
+  const multiLinerInput = `
+    yappingStarts
+      this is a comment
+    yappingEnds
+  `;
+  const multiLinerExpected = `\n/*\n  this is a comment\n*/\n"use strict";`;
+  const multiLinerOutput = babel.transform(multiLinerInput, {
+    filename: "./../src/example.js",
+    plugins: [glowupVibes],
+  }).code;
+  expect(multiLinerOutput).toEqual(multiLinerExpected);
+});
+

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -382,7 +382,7 @@ test("Should replace yappingStarts and yappingEnds with /* and */", () => {
   expect(multiLinerOutput).toEqual(multiLinerExpected);
 });
 
-test("Should replace yap with * if in comment (supports yapdoc)", () => {
+test("Should replace yap with * if in block comment (supports yapdoc)", () => {
   const input = `
     yappingStarts yap
       yap this is a comment
@@ -397,3 +397,15 @@ test("Should replace yap with * if in comment (supports yapdoc)", () => {
   expect(output).toEqual(expected);
 });
 
+test("Should replace yap with // if not already in comment", () => {
+  const input = `
+    yap Single line comment
+    console.log("hello"); yap "hello"
+  `;
+  const expected = '"use strict";\n\n// Single line comment\nconsole.log("hello"); // "hello"';
+  const output = babel.transform(input, {
+    filename: "./../src/example.js",
+    plugins: [glowupVibes],
+  }).code;
+  expect(output).toEqual(expected);
+});

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -382,3 +382,18 @@ test("Should replace yappingStarts and yappingEnds with /* and */", () => {
   expect(multiLinerOutput).toEqual(multiLinerExpected);
 });
 
+test("Should replace yap with * if in comment (supports yapdoc)", () => {
+  const input = `
+    yappingStarts yap
+      yap this is a comment
+      yap as is this
+    yappingEnds
+  `;
+  const expected = `\n/**\n * this is a comment\n * as is this\n */\n"use strict";`;
+  const output = babel.transform(input, {
+    filename: "./../src/example.js",
+    plugins: [glowupVibes],
+  }).code;
+  expect(output).toEqual(expected);
+});
+


### PR DESCRIPTION
## This PR

- Allows comments via `yap*` variant keywords.
- Adds tests for yapping.
- Demonstrates yapping in example and compiled code files.
- Updates README.md with yapping examples (sorry, had to make the table an ugly amount wider for this!)

## Examples

`yap`, if not inside a JSDoc comment, becomes `//`.

```js
yap gyatt

// gyatt
```

`yappingStarts` and `yappingEnds` delimit a block comment (`/* */`). Line breaks not necessary.

```js
yappingStarts
  hits different
yappingEnds

/*
  hits different
*/
```

`yappingStarts yap` opens a JSDoc comment instead (`/**`) and `yap` inside these will become `*` instead of `//`.

```js
yappingStarts yap
  yap @param {string} code
  yap @returns {string}
yappingEnds

/**
 * @param {string} code
 * @returns {string}
 */
```

---

Unfortunately, I couldn't "enhance" the JSDoc's contents with plugin keywords (would've loved `@drop {(onGod | ohio)}`) as they're handled differently by Babel than non-comment tokens. I didn't look much into how this bit worked so I've no idea how involved or simple implementing that would be.

All tests pass other than `toilet`, but that's for a separate PR.