### PR TITLE
Fix toilet

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,10 +39,10 @@ module.exports = function () {
       node.expression.type === "CallExpression" &&
       ["itsGiving", "drop", "toilet"].includes(node.expression.callee.name)
     ) {
-      const errorArgument = node.expression.arguments[0];
+      const returnValue = node.expression.arguments[0];
       const returnStatement = {
         type: "ReturnStatement",
-        argument: errorArgument,
+        argument: returnValue,
       };
       path.replaceWith(returnStatement);
     }

--- a/index.js
+++ b/index.js
@@ -37,9 +37,7 @@ module.exports = function () {
 
     if (
       node.expression.type === "CallExpression" &&
-      (node.expression.callee.name === "itsGiving" ||
-        node.expression.callee.name === "drop" ||
-        node.expression.callee.name === "toilet")
+      ["itsGiving", "drop", "toilet"].includes(node.expression.callee.name)
     ) {
       const errorArgument = node.expression.arguments[0];
       const returnStatement = {

--- a/index.js
+++ b/index.js
@@ -38,14 +38,15 @@ module.exports = function () {
     if (
       node.expression.type === "CallExpression" &&
       (node.expression.callee.name === "itsGiving" ||
-        node.expression.callee.name === "drop")
+        node.expression.callee.name === "drop" ||
+        node.expression.callee.name === "toilet")
     ) {
       const errorArgument = node.expression.arguments[0];
-      const throwStatement = {
+      const returnStatement = {
         type: "ReturnStatement",
         argument: errorArgument,
       };
-      path.replaceWith(throwStatement);
+      path.replaceWith(returnStatement);
     }
 
     if (

--- a/lib/compiled.js
+++ b/lib/compiled.js
@@ -13,7 +13,7 @@ function vibeCheck() {
   const totalAura = aura.filter(point => point);
   const filteredAura = aura.reduce(point => point > 5);
   auraPoints.filter(() => {
-    return(null);
+    return null;
   });
   const myGuy = {
     heat: "Yuh I'm droppin dis heat ❗❗",


### PR DESCRIPTION
The current test for `toilet` fails as `toilet(1)` transpiles to `return(1)`

## This PR

- Includes `toilet` in conditional for `CallExpression`->`ReturnStatement` replacement.
- Refactors conditional due to number of comparisons.
- Renames variables (likely was carryover from copy/pasting from different section).