### PR TITLE
Convert chained fAround/findOut/eitherWay to try/catch/finally

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Note: this was designed using Babel 7 and I haven't tested it on anything else. 
 | arr.justPutTheFriesInTheBagBro(args)            | arr.reduce(args)                                     |
 | toilet(thingToReturn)                           | return thingToReturn;                                |
 | ohio                                            | null                                                 |
+| fuckAround(()=>{}).findOut((L)=>{}).eitherWay(()=>{}) | try {} catch (L) {} finally {}                 |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Note: this was designed using Babel 7 and I haven't tested it on anything else. 
 | arr.justPutTheFriesInTheBagBro(args)                                   | arr.reduce(args)                                     |
 | toilet(thingToReturn)                                                  | return thingToReturn;                                |
 | ohio                                                                   | null                                                 |
-| fuckAround(()=>{}).findOut((L)=>{}).eitherWay(()=>{})                  | try {} catch (L) {} finally {}                       |
+| fAround(()=>{}).findOut((L)=>{}).eitherWay(()=>{})                     | try {} catch (L) {} finally {}                       |
 | yap single line comment                                                | // single line comment                               |
 | yappingStarts block comment yappingEnds                                | /* block comment */                                  |
 | <pre>yappingStarts yap<br>  yap @returns {string}<br>yappingEnds</pre> | <pre>/**<br> * @returns {string}<br> */</pre>        |

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ module.exports = function () {
         const argument = token.arguments[0];
         const callee = token.callee;
 
-        if (callee.name === "fuckAround") {
+        if (callee.name === "fAround") {
           return { try: { body: argument.body } };
         }
 

--- a/lib/compiled.js
+++ b/lib/compiled.js
@@ -12,6 +12,13 @@ function vibeCheck() {
   const aura = auraPoints.map(point => point * 2);
   const totalAura = aura.filter(point => point);
   const filteredAura = aura.reduce(point => point > 5);
+  try {
+    sis();
+  } catch (err) {
+    console.error("big yikes");
+  } finally {
+    return null;
+  }
   auraPoints.filter(() => {
     return(null);
   });

--- a/src/example.js
+++ b/src/example.js
@@ -12,6 +12,16 @@ function vibeCheck() {
   const totalAura = aura.skibidi((point) => point);
   const filteredAura = aura.justPutTheFriesInTheBagBro((point) => point > 5);
 
+  fuckAround(() => {
+    sis();
+  })
+    .findOut((err) => {
+      lowkey.cringe("big yikes");
+    })
+    .eitherWay(() => {
+      ghosted;
+    });
+
   auraPoints.skibidi(() => {
     toilet(ohio)
   });

--- a/src/example.js
+++ b/src/example.js
@@ -15,7 +15,7 @@ function vibeCheck() {
   const totalAura = aura.skibidi((point) => point);
   const filteredAura = aura.justPutTheFriesInTheBagBro((point) => point > 5);
 
-  fuckAround(() => {
+  fAround(() => {
     sis();
   })
     .findOut((err) => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -359,3 +359,58 @@ test("Should replace ohio with reduce", () => {
   }).code;
   expect(output).toEqual(expected);
 });
+
+test("Converts fuckAround/findOut functions to try/catch blocks", () => {
+  const input = `
+    fuckAround(() => {
+      console.log("try");
+    }).findOut((err) => {
+      console.error("catch");
+    });
+  `;
+  const expected = `"use strict";\n\ntry {\n  console.log("try");\n} catch (err) {\n  console.error("catch");\n}`;
+  const output = babel.transform(input, {
+    filename: "./../src/example.js",
+    plugins: [glowupVibes],
+  }).code;
+  expect(output).toEqual(expected);
+});
+
+
+test("Treats eitherWay as finally block if chained to fuckAround/findOut", () => {
+  const input = `
+    fuckAround(() => {
+      console.log("try");
+    }).findOut((err) => {
+      console.error("catch");
+    }).eitherWay(() => {
+      console.info("finally");
+    });
+  `;
+  const expected = `"use strict";\n\ntry {\n  console.log("try");\n} catch (err) {\n  console.error("catch");\n} finally {\n  console.info("finally");\n}`;
+  const output = babel.transform(input, {
+    filename: "./../src/example.js",
+    plugins: [glowupVibes],
+  }).code;
+  expect(output).toEqual(expected);
+});
+
+test("Does not treat fuckAround/findOut/eitherWay as try/catch/finally if not chained", () => {
+  const input = `
+    fuckAround(() => {
+      console.log("try");
+    });
+    findOut((err) => {
+      console.error("catch");
+    });
+    eitherWay(() => {
+      console.info("finally");
+    });
+  `;
+  const expected = `"use strict";\n\nfuckAround(() => {\n  console.log("try");\n});\nfindOut(err => {\n  console.error("catch");\n});\neitherWay(() => {\n  console.info("finally");\n});`;
+  const output = babel.transform(input, {
+    filename: "./../src/example.js",
+    plugins: [glowupVibes],
+  }).code;
+  expect(output).toEqual(expected);
+})

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -311,10 +311,7 @@ test("Converts fAround/findOut functions to try/catch blocks", () => {
     });
   `;
   const expected = `"use strict";\n\ntry {\n  console.log("try");\n} catch (err) {\n  console.error("catch");\n}`;
-  const output = babel.transform(input, {
-    filename: "./../src/example.js",
-    plugins: [glowupVibes],
-  }).code;
+  const output = babel.transform(input, OPTS).code;
   expect(output).toEqual(expected);
 });
 
@@ -329,10 +326,7 @@ test("Treats eitherWay as finally block if chained to fAround/findOut", () => {
     });
   `;
   const expected = `"use strict";\n\ntry {\n  console.log("try");\n} catch (err) {\n  console.error("catch");\n} finally {\n  console.info("finally");\n}`;
-  const output = babel.transform(input, {
-    filename: "./../src/example.js",
-    plugins: [glowupVibes],
-  }).code;
+  const output = babel.transform(input, OPTS).code;
   expect(output).toEqual(expected);
 });
 
@@ -349,9 +343,6 @@ test("Does not treat fAround/findOut/eitherWay as try/catch/finally if not chain
     });
   `;
   const expected = `"use strict";\n\nfAround(() => {\n  console.log("try");\n});\nfindOut(err => {\n  console.error("catch");\n});\neitherWay(() => {\n  console.info("finally");\n});`;
-  const output = babel.transform(input, {
-    filename: "./../src/example.js",
-    plugins: [glowupVibes],
-  }).code;
+  const output = babel.transform(input, OPTS).code;
   expect(output).toEqual(expected);
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -410,9 +410,9 @@ test("Should replace yap with // if not already in comment", () => {
   expect(output).toEqual(expected);
 });
 
-test("Converts fuckAround/findOut functions to try/catch blocks", () => {
+test("Converts fAround/findOut functions to try/catch blocks", () => {
   const input = `
-    fuckAround(() => {
+    fAround(() => {
       console.log("try");
     }).findOut((err) => {
       console.error("catch");
@@ -426,9 +426,9 @@ test("Converts fuckAround/findOut functions to try/catch blocks", () => {
   expect(output).toEqual(expected);
 });
 
-test("Treats eitherWay as finally block if chained to fuckAround/findOut", () => {
+test("Treats eitherWay as finally block if chained to fAround/findOut", () => {
   const input = `
-    fuckAround(() => {
+    fAround(() => {
       console.log("try");
     }).findOut((err) => {
       console.error("catch");
@@ -444,9 +444,9 @@ test("Treats eitherWay as finally block if chained to fuckAround/findOut", () =>
   expect(output).toEqual(expected);
 });
 
-test("Does not treat fuckAround/findOut/eitherWay as try/catch/finally if not chained", () => {
+test("Does not treat fAround/findOut/eitherWay as try/catch/finally if not chained", () => {
   const input = `
-    fuckAround(() => {
+    fAround(() => {
       console.log("try");
     });
     findOut((err) => {
@@ -456,7 +456,7 @@ test("Does not treat fuckAround/findOut/eitherWay as try/catch/finally if not ch
       console.info("finally");
     });
   `;
-  const expected = `"use strict";\n\nfuckAround(() => {\n  console.log("try");\n});\nfindOut(err => {\n  console.error("catch");\n});\neitherWay(() => {\n  console.info("finally");\n});`;
+  const expected = `"use strict";\n\nfAround(() => {\n  console.log("try");\n});\nfindOut(err => {\n  console.error("catch");\n});\neitherWay(() => {\n  console.info("finally");\n});`;
   const output = babel.transform(input, {
     filename: "./../src/example.js",
     plugins: [glowupVibes],


### PR DESCRIPTION
Closes #60 

#88 (which this will also close) Has been untouched for a long time and also looks like it doesn't fully cover the desired conversion.

The function/callback syntax was chosen because even though this could be handled by the pre-parser (to allow `faround {} findout {} eitherway {}` syntax), that would require additional logic to determine if inside a comment so that only intended keywords are substituted. The current approach feels easier to reason about.

## This PR

- Converts *chained* `fAround`, `findOut` and `eitherWay` functions (`eitherWay` is optional) to `try/catch/(finally)` - if not chained then they are treated as normal function calls.
- Adds tests for conversion.
- Updates example/compiled/README files with examples.